### PR TITLE
Adds python 3.5 support to tox environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,flake8,lint2,lint3
+envlist = py27,py33,py34,py35,flake8,lint2,lint3
 minversion = 1.6
 skipsdist = True
 


### PR DESCRIPTION
Now that python 3.5 is available, we should use it in our tox.ini.
