### PR TITLE
Adds keyspace creation support to cdeploy

### DIFF
--- a/cdeploy/test/migrations/config/cassandra.yml
+++ b/cdeploy/test/migrations/config/cassandra.yml
@@ -5,3 +5,9 @@ development:
 test:
     hosts: [cassandra.local]
     keyspace: migrations_test
+
+keyspace:
+    hosts: [cassandra.local]
+    keyspace: migrations_keyspace_test
+    create_keyspace: true
+    replication_strategy: "{'class': 'SimpleStrategy', 'replication_factor': '1'}"

--- a/cdeploy/test/migrator_test.py
+++ b/cdeploy/test/migrator_test.py
@@ -120,6 +120,13 @@ class SessionTests(unittest.TestCase):
             'keyspace': 'test',
         }
 
+        self.session = mock.Mock()
+        self.session.set_keyspace.return_value = None
+
+        self.returned_cluster = mock.Mock()
+        self.returned_cluster.connect.return_value = self.session
+        self.mock_cluster.return_value = self.returned_cluster
+
     def test_auth_disabled(self):
         migrator.get_session(self.config)
 
@@ -196,6 +203,39 @@ class SessionTests(unittest.TestCase):
             cassandra.ConsistencyLevel.EACH_QUORUM,
             session.default_consistency_level,
         )
+
+    def test_nonexistent_keyspace_create_enabled(self):
+        self.config['create_keyspace'] = True
+        self.config['replication_strategy'] = 'test'
+
+        self.session.set_keyspace.side_effect = [
+            cassandra.InvalidRequest,
+            None
+        ]
+
+        migrator.get_session(self.config)
+        ((args,), _) = self.session.set_keyspace.call_args
+        self.assertEqual(self.config["keyspace"], args)
+
+        ((args,), _) = self.session.execute.call_args
+        self.assertEqual(
+            "CREATE KEYSPACE {0} WITH REPLICATION = {1};".format(
+                self.config["keyspace"],
+                self.config["replication_strategy"]
+            ),
+            args
+        )
+
+    def test_nonexistent_keyspace_create_disabled(self):
+        self.config['create_keyspace'] = False
+
+        self.session.set_keyspace.side_effect = cassandra.InvalidRequest
+
+        with self.assertRaises(cassandra.InvalidRequest):
+            migrator.get_session(self.config)
+
+        ((args,), _) = self.session.set_keyspace.call_args
+        self.assertEqual(self.config["keyspace"], args)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Cdeploy can now optionally create the keyspace if nonexistent upon time of migration.