### PR TITLE
Adds fix for cassandra-driver 3.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-env:
-  - CASS_DRIVER_NO_CYTHON=1
 sudo: false
 language: "python"
 python:
@@ -8,3 +6,8 @@ before_install:
   - "pip install tox"
 script:
   - "tox"
+services:
+  - cassandra
+addons:
+  hosts:
+    - cassandra.local

--- a/cdeploy/cqlexecutor.py
+++ b/cdeploy/cqlexecutor.py
@@ -16,7 +16,7 @@ class CQLExecutor:
 
     @staticmethod
     def get_top_version(session):
-        return session.execute('SELECT * FROM schema_migrations LIMIT 1')
+        return list(session.execute('SELECT * FROM schema_migrations LIMIT 1'))
 
     @staticmethod
     def execute(session, script):

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     url='https://github.com/rackerlabs/cdeploy',
     keywords=['cassandra', 'migrations'],
     packages=find_packages(),
-    install_requires=['PyYAML', 'cassandra-driver'],
+    install_requires=['PyYAML', 'cassandra-driver>=3.0.0'],
     tests_require=['mock'],
     test_suite="cdeploy.test",
     entry_points={

--- a/tox.ini
+++ b/tox.ini
@@ -1,36 +1,28 @@
 [tox]
-envlist = py27,py33,py34,flake8,lint2,lint3
-minversion = 1.6
+envlist =
+    py{27,33,34}-nose,
+    py{27,33,34}-lint,
+    flake
+minversion = 1.8
 skipsdist = True
 
 [testenv]
-commands = nosetests --exclude integration_test.py
-deps = nose
-install_command = pip install --upgrade {opts} {packages}
-setenv = VIRTUAL_ENV={envdir}
-         NOSE_WITH_OPENSTACK=1
-         NOSE_OPENSTACK_COLOR=1
-         NOSE_OPENSTACK_RED=0.05
-         NOSE_OPENSTACK_YELLOW=0.025
-         NOSE_OPENSTACK_SHOW_ELAPSED=1
-         NOSE_OPENSTACK_STDOUT=1
+commands =
+    flake: flake8 --exclude ".venv*"
+    nose: nosetests
+    lint: pylint ./cdeploy
+deps =
+    flake: flake8
+    lint: pylint
+    nose: nose
+    py27: -r{toxinidir}/test-requirements-2.txt
+setenv =
+    CASS_DRIVER_NO_CYTHON=1
+    VIRTUAL_ENV={envdir}
+    NOSE_WITH_OPENSTACK=1
+    NOSE_OPENSTACK_COLOR=1
+    NOSE_OPENSTACK_RED=0.05
+    NOSE_OPENSTACK_YELLOW=0.025
+    NOSE_OPENSTACK_SHOW_ELAPSED=1
+    NOSE_OPENSTACK_STDOUT=1
 usedevelop = True
-
-[testenv:py27]
-deps = {[testenv]deps}
-       -r{toxinidir}/test-requirements-2.txt
-
-[testenv:flake8]
-commands = flake8 --exclude ".venv*"
-deps = flake8
-
-[testenv:lint2]
-basepython = python2
-commands = pylint ./cdeploy
-deps = -r{toxinidir}/test-requirements-2.txt
-       pylint
-
-[testenv:lint3]
-basepython = python3
-commands = pylint ./cdeploy
-deps = pylint


### PR DESCRIPTION
A major update to the python cassandra-driver introduced a change to the return value of 'execute'.  The new return value (ResultSet) is a paginated iterator, whereas the old value was a list.

Attempting to perform a length operation now fails and instead requires all pages to be fetched to determine the number of results returned.