### PR TITLE
Filtering for .cql files in migrations folder and python 2.6 support

### DIFF
--- a/cdeploy/migrator.py
+++ b/cdeploy/migrator.py
@@ -175,9 +175,9 @@ def get_session(config):
     conlevel = cassandra.ConsistencyLevel.name_to_value  # Convenience alias.
     converters = {'default_consistency_level': (lambda s: conlevel[s])}
 
-    sessionopts = {optmap[arg]: config[arg]
-                   for arg in optmap.keys()
-                   if arg in config}
+    sessionopts = dict((optmap[arg], config[arg])
+                       for arg in optmap.keys()
+                       if arg in config)
 
     for opt, value in sessionopts.items():
         if opt in converters:

--- a/cdeploy/migrator.py
+++ b/cdeploy/migrator.py
@@ -144,25 +144,23 @@ def main():
 
 
 def get_session(config):
-    auth_provider = None
+    kwargs_dict = dict(contact_points=config['hosts'])
     if 'auth_enabled' in config and config['auth_enabled']:
-        auth_provider = auth.PlainTextAuthProvider(
+        kwargs_dict['auth_provider'] = auth.PlainTextAuthProvider(
             username=config['auth_username'],
             password=config['auth_password'],
         )
 
-    ssl_options = None
     if 'ssl_enabled' in config and config['ssl_enabled']:
-        ssl_options = {
+        kwargs_dict['ssl_options'] = {
             'ca_certs': config['ssl_ca_certs'],
             'ssl_version': ssl.PROTOCOL_TLSv1,  # pylint: disable=E1101
         }
+    if 'port' in config and config['port']:
+        # Cluster will default to port 9042 if unspecified
+        kwargs_dict['port'] = config['port']
 
-    cluster = Cluster(
-        config['hosts'],
-        auth_provider=auth_provider,
-        ssl_options=ssl_options,
-    )
+    cluster = Cluster(**kwargs_dict)
 
     session = cluster.connect()
 

--- a/cdeploy/migrator.py
+++ b/cdeploy/migrator.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import fnmatch
 import os
 import ssl
 import sys
@@ -87,6 +88,7 @@ class Migrator(object):
         dir_list = os.listdir(self.migrations_path)
         if 'config' in dir_list:
             dir_list.remove('config')
+        dir_list = [f for f in dir_list if fnmatch.fnmatch(f, '*.cql')]
         migration_dir_listing = sorted(dir_list, key=self.migration_version)
         return filter(
             filter_func,

--- a/cdeploy/test/migrations/003_add_lastname.cql.old
+++ b/cdeploy/test/migrations/003_add_lastname.cql.old
@@ -1,0 +1,3 @@
+ALTER TABLE users ADD lastname text;
+--//@UNDO
+ALTER TABLE users DROP lastname

--- a/cdeploy/test/migrator_test.py
+++ b/cdeploy/test/migrator_test.py
@@ -37,7 +37,7 @@ class ApplyingMigrationTests(unittest.TestCase):
             self.session
         )
 
-    def test_it_should_initially_apply_all_the_migrations(self):
+    def test_it_should_initially_apply_all_valid_migrations(self):
         cqlexecutor.CQLExecutor.execute = mock.Mock()
         self.migrator.run_migrations()
         cqlexecutor.CQLExecutor.execute.assert_has_calls([
@@ -54,7 +54,7 @@ class ApplyingMigrationTests(unittest.TestCase):
             mock.call(self.session, 2)
         ])
 
-    def test_it_should_only_run_migrations_that_have_not_been_applied(self):
+    def test_it_should_only_run_valid_migrations_that_have_not_been_applied(self):
         cqlexecutor.CQLExecutor.execute = mock.Mock()
         self.migrator.get_top_version = mock.Mock(return_value=1)
         self.migrator.run_migrations()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='cdeploy',
-    version='1.6',
+    version='1.6-SK',
     description='A tool for managing Cassandra schema migrations',
     author='David McHoull',
     author_email='dmchoull@gmail.com',


### PR DESCRIPTION
Fixes issue #25 by only processing files with the .cql extension in the migrations folder.
Also changed dictionary comprehension to support python 2.6
