### PR TITLE
Add a --dry-run option

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Additional configuration parameters for Cassandra are available:
         auth_enabled: true
         auth_username: username
         auth_password: password
+        port: 9042
         ssl_enabled: true
         ssl_ca_certs: /path/to/ca/certs
         consistency_level: ALL

--- a/cdeploy/migrator.py
+++ b/cdeploy/migrator.py
@@ -157,9 +157,14 @@ def get_cluster(config):
             'ca_certs': config['ssl_ca_certs'],
             'ssl_version': ssl.PROTOCOL_TLSv1,  # pylint: disable=E1101
         }
+    port = '9042'
+    if 'port' in config:
+        port = config['port']
+
     cluster = Cluster(
         config['hosts'],
         auth_provider=auth_provider,
+        port=port,
         ssl_options=ssl_options,
     )
     return cluster

--- a/cdeploy/test/integration_test.py
+++ b/cdeploy/test/integration_test.py
@@ -29,10 +29,11 @@ def reset_db(keyspace):
 
 def run_migrator(arg=''):
     test_dir = os.path.dirname(os.path.realpath(__file__))
-    os.system(
+    result = os.system(
         'cd {0}/..; python migrator.py test/migrations {1}'.format(test_dir,
                                                                    arg)
     )
+    return result
 
 
 def do_undo():
@@ -89,6 +90,19 @@ class DatabaseEnvironmentsTest(unittest.TestCase):
             'SELECT * FROM migrations_test.schema_migrations LIMIT 1'
         )
         self.assertEquals(result[0].version, 2)
+
+
+class PortConfigTest(unittest.TestCase):
+    def setUp(self):
+        reset_db('port_test')
+
+    def tearDown(self):
+        os.unsetenv('ENV')
+
+    def test_port_configured(self):
+        os.putenv('ENV', 'port')
+        result = run_migrator()
+        self.assertEquals(result,0)
 
 
 if __name__ == '__main__':

--- a/cdeploy/test/integration_test.py
+++ b/cdeploy/test/integration_test.py
@@ -102,7 +102,7 @@ class PortConfigTest(unittest.TestCase):
     def test_port_configured(self):
         os.putenv('ENV', 'port')
         result = run_migrator()
-        self.assertEquals(result,0)
+        self.assertEquals(result, 0)
 
 
 if __name__ == '__main__':

--- a/cdeploy/test/migrations/config/cassandra.yml
+++ b/cdeploy/test/migrations/config/cassandra.yml
@@ -11,3 +11,8 @@ keyspace:
     keyspace: migrations_keyspace_test
     create_keyspace: true
     replication_strategy: "{'class': 'SimpleStrategy', 'replication_factor': '1'}"
+
+port:
+    hosts: [cassandra.local]
+    port: 9042
+    keyspace: port_test


### PR DESCRIPTION
This went a bit deeper into the code than originally anticipated, but I wanted to make sure the keyspace and schema_migration tables do not get created on a --dry-run invocation.